### PR TITLE
[Refactor] Replace Boolean Result with a Result Object in `extract` Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ below demonstrates using `SevenZipAdapter` for archive, but you can add your own
 use Esplora\Lumos\Extractor;
 use Esplora\Lumos\Adapters\SevenZipAdapter;
 
-Extractor::make([
-    // Specify which file adapters will be used
-    new SevenZipAdapter(),
-])
-->extract('/path/to/your/archive.zip', '/path/to/extract/to');
-// Process a file (returns a boolean depending on the outcome)
+$lumos = Extractor::make()
+    ->withAdapter(new SevenZipAdapter())
+    ->extract('/path/to/your/archive.zip');
+
+$lumos->isSuccessful(); // true
+$lumos->steps()->count(); // 1
 ```
 
 > [!NOTE]
@@ -57,14 +57,18 @@ use Esplora\Lumos\Extractor;
 use Esplora\Lumos\Adapters\SevenZipAdapter;
 use Esplora\Lumos\Providers\ArrayPasswordProvider;
 
-Extractor::make([
-    new SevenZipAdapter(),
-])
-    ->withPasswords(new ArrayPasswordProvider([
-        'qwerty',
-        'xxx123',
-    ]))
-    ->extract('/path/to/your/archive.zip', '/path/to/save/to');
+$passwords = new ArrayPasswordProvider([
+    'qwerty',
+    'xxx123',
+]);
+
+Extractor::make()
+    ->withAdapters([
+        new SevenZipAdapter(),
+    ])
+    ->withPasswords($passwords)
+    ->extract('/path/to/your/archive.zip', '/path/to/save/to')
+    ->isSuccessful(); // false
 ```
 
 If needed, you can create your own password provider by implementing the `PasswordProviderInterface`.
@@ -73,35 +77,6 @@ If needed, you can create your own password provider by implementing the `Passwo
 > If you don’t have a password database but want to try all possible combinations, you can
 > use [SecLists](https://github.com/danielmiessler/SecLists/tree/master/Passwords) as a source of popular passwords for
 > brute-forcing.
-
-### Event Handling
-
-For more control over the file processing, you can add event handlers. This allows you to receive information about the
-reasons for failures or respond to successful completions.
-
-```php
-use Esplora\Lumos\Extractor;
-use Esplora\Lumos\Adapters\SevenZipAdapter;
-use Esplora\Lumos\Providers\ArrayPasswordProvider;
-
-Extractor::make([
-    new SevenZipAdapter(),
-])
-    ->withPasswords(new ArrayPasswordProvider([
-        'qwerty',
-        'xxx123',
-    ]))
-    ->onSuccess(function ($file, $output) {
-        // Processing completed successfully!
-    })
-    ->onPasswordFailure(function ($file, $output) {
-        // The password was incorrect
-    })
-    ->onFailure(function ($throwable, $file, $output) {
-        // Handle the failure
-    })
-    ->extract('/path/to/your/archive.zip', '/path/to/save/to');
-```
 
 ### Testing
 

--- a/src/Adapters/MSOfficeCryptoToolAdapter.php
+++ b/src/Adapters/MSOfficeCryptoToolAdapter.php
@@ -58,7 +58,6 @@ class MSOfficeCryptoToolAdapter implements AdapterInterface
         $process = new Process($command);
         $process->run();
 
-
         // When password exist and the process is successful, the file is decrypted
         if ($password !== null) {
             $this->summary()

--- a/src/Adapters/MSOfficeCryptoToolAdapter.php
+++ b/src/Adapters/MSOfficeCryptoToolAdapter.php
@@ -58,17 +58,27 @@ class MSOfficeCryptoToolAdapter implements AdapterInterface
         $process = new Process($command);
         $process->run();
 
+
         // When password exist and the process is successful, the file is decrypted
         if ($password !== null) {
+            $this->summary()
+                ->addStepWithProcess($process->isSuccessful(), $process, $password);
+
             return $process->isSuccessful();
         }
 
         // When password is not provided, check output for 'not encrypted' message
         if (! str_contains($process->getErrorOutput(), 'not encrypted')) {
+            $this->summary()
+                ->addStepWithProcess(false, $process, $password);
+
             return false;
         }
 
         copy($filePath, $destination);
+
+        $this->summary()
+            ->addStepWithProcess(true, $process, $password);
 
         return true;
     }

--- a/src/Adapters/QpdfAdapter.php
+++ b/src/Adapters/QpdfAdapter.php
@@ -56,6 +56,9 @@ class QpdfAdapter implements AdapterInterface
         $process = new Process($command);
         $process->run();
 
+        $this->summary()
+            ->addStepWithProcess($process->isSuccessful(), $process, $password);
+
         return $process->isSuccessful();
     }
 

--- a/src/Adapters/SevenZipAdapter.php
+++ b/src/Adapters/SevenZipAdapter.php
@@ -65,6 +65,9 @@ class SevenZipAdapter implements AdapterInterface
         $process = new Process($command);
         $process->run();
 
+        $this->summary()
+            ->addStepWithProcess($process->isSuccessful(), $process, $password);
+
         return $process->isSuccessful();
     }
 

--- a/src/Concerns/Decryptable.php
+++ b/src/Concerns/Decryptable.php
@@ -3,10 +3,11 @@
 namespace Esplora\Lumos\Concerns;
 
 use Esplora\Lumos\Contracts\PasswordProviderInterface;
+use Esplora\Lumos\Contracts\SummaryInterface;
 
 trait Decryptable
 {
-    use DirectoryEnsurer;
+    use DirectoryEnsurer, HasSummary;
 
     /**
      * Removes the password or extract from an files using adapters.
@@ -14,26 +15,24 @@ trait Decryptable
      * @param string                    $filePath    Path to the to file.
      * @param string                    $destination Path where the file will be saved.
      * @param PasswordProviderInterface $passwords   List of passwords to try for decrypting the file.
-     *
-     * @return bool Returns true if decryption was successful, false otherwise.
      */
-    public function extract(string $filePath, string $destination, PasswordProviderInterface $passwords): bool
+    public function extract(string $filePath, string $destination, PasswordProviderInterface $passwords): SummaryInterface
     {
         $this->ensureDirectoryExists($destination);
 
         // First, try to open the file without a password
         if ($this->tryDecrypting($filePath, $destination)) {
-            return true; // Successfully opened without password
+            return $this->summary(); // Successfully opened without password
         }
 
         // If that fails, try each provided password
         foreach ($passwords->getPasswords() as $password) {
             if ($this->tryDecrypting($filePath, $destination, $password)) {
-                return true; // Successfully decrypted with password
+                return $this->summary(); // Successfully decrypted with password
             }
         }
 
-        return false; // Decryption failed
+        return $this->summary(); // Decryption failed
     }
 
     /**

--- a/src/Concerns/HasSummary.php
+++ b/src/Concerns/HasSummary.php
@@ -15,7 +15,7 @@ trait HasSummary
      */
     protected function summary(): Summary
     {
-        $this->summary ??= new Summary();
+        $this->summary ??= new Summary;
 
         return $this->summary;
     }

--- a/src/Concerns/HasSummary.php
+++ b/src/Concerns/HasSummary.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Esplora\Lumos\Concerns;
+
+use Esplora\Lumos\Summary;
+
+trait HasSummary
+{
+    private ?Summary $summary = null;
+
+    /**
+     * Initializes and returns the current summary object.
+     *
+     * @return Summary
+     */
+    protected function summary(): Summary
+    {
+        $this->summary ??= new Summary();
+
+        return $this->summary;
+    }
+}

--- a/src/Contracts/AdapterInterface.php
+++ b/src/Contracts/AdapterInterface.php
@@ -39,8 +39,6 @@ interface AdapterInterface
      * @param string                    $destination Directory where the archive will be extracted. The directory will be created if it does not exist.
      * @param PasswordProviderInterface $passwords   Password provider object to attempt extraction if the archive is password-protected.
      *                                               This can be an array or any iterable object containing password strings.
-     *
-     * @return bool Returns true if extraction was successful, false otherwise.
      */
-    public function extract(string $filePath, string $destination, PasswordProviderInterface $passwords): bool;
+    public function extract(string $filePath, string $destination, PasswordProviderInterface $passwords): SummaryInterface;
 }

--- a/src/Contracts/SummaryInterface.php
+++ b/src/Contracts/SummaryInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Esplora\Lumos\Contracts;
+
+use Illuminate\Support\Collection;
+
+interface SummaryInterface
+{
+    /**
+     * Добавить шаг в отчет.
+     *
+     * @param bool  $success Успешность текущего шага.
+     * @param array $context Контекст текущего шага.
+     *
+     * @return static
+     */
+    public function addStep(bool $success, array $context = []): static;
+
+    /**
+     * Получить все шаги отчета.
+     *
+     * @return Collection
+     */
+    public function steps(): Collection;
+
+    /**
+     * Проверить успешность всего процесса.
+     *
+     * @return bool
+     */
+    public function isSuccessful(): bool;
+
+    /**
+     * Получить количество попыток.
+     *
+     * @return int
+     */
+    public function attempts(): int;
+}

--- a/src/Summary.php
+++ b/src/Summary.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Esplora\Lumos;
+
+use Esplora\Lumos\Contracts\SummaryInterface;
+use Illuminate\Support\Collection;
+use Symfony\Component\Process\Process;
+
+class Summary implements SummaryInterface
+{
+    /**
+     * Успешность извлечения.
+     *
+     * @var bool
+     */
+    protected bool $success = false;
+
+    /**
+     * Количество попыток извлечения.
+     *
+     * @var int
+     */
+    protected int $attempts = 0;
+
+    /**
+     * Шаги извлечения.
+     *
+     * @var \Illuminate\Support\Collection
+     */
+    protected Collection $steps;
+
+    /**
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->steps = collect();
+    }
+
+    /**
+     * Добавляет шаг в отчет.
+     *
+     * @param bool  $success Успешность текущего шага.
+     * @param array $context Контекст текущего шага.
+     *
+     * @return $this For method chaining.
+     */
+    public function addStep(bool $success, array $context = []): static
+    {
+        if ($success) {
+            $this->success = true;
+        }
+
+        $this->attempts++;
+
+        $contextHash = $this->hashContext($success, $context);
+
+        // Добавляем только уникальные шаги
+        if ($this->steps->has($contextHash)) {
+            return $this;
+        }
+
+        $this->steps->put($contextHash, [
+            'success' => $success,
+            'context' => $context,
+        ]);
+
+        return $this;
+    }
+
+    /**
+     * Генерирует уникальный хеш для шага.
+     *
+     * @param bool  $success Успешность шага.
+     * @param array $context Контекст шага.
+     *
+     * @return string
+     */
+    protected function hashContext(bool $success, array $context): string
+    {
+        return sha1(json_encode([
+            'success' => $success,
+            'context' => $context,
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+    }
+
+    /**
+     * Возвращает все шаги отчета.
+     *
+     * @return Collection
+     */
+    public function steps(): Collection
+    {
+        return $this->steps;
+    }
+
+    /**
+     * Проверяет успешность всего процесса.
+     *
+     * @return bool
+     */
+    public function isSuccessful(): bool
+    {
+        return $this->success;
+    }
+
+    /**
+     * Получить количество попыток.
+     *
+     * @return int
+     */
+    public function attempts(): int
+    {
+        return $this->attempts++;
+    }
+
+    /**
+     * @param bool                               $success
+     * @param \Symfony\Component\Process\Process $process
+     * @param string|null                        $password
+     *
+     * @return $this For method chaining.
+     */
+    public function addStepWithProcess(bool $success, Process $process, string $password = null): static
+    {
+        return $this->addStep($success, [
+            'isSuccessful' => $process->isSuccessful(),
+            'output'       => $process->getOutput(),
+            'error'        => $process->getErrorOutput(),
+            'exitCode'     => $process->getExitCode(),
+            'exitCodeText' => $process->getExitCodeText(),
+            'password'     => $password,
+        ]);
+    }
+}

--- a/src/Summary.php
+++ b/src/Summary.php
@@ -121,7 +121,7 @@ class Summary implements SummaryInterface
      *
      * @return $this For method chaining.
      */
-    public function addStepWithProcess(bool $success, Process $process, string $password = null): static
+    public function addStepWithProcess(bool $success, Process $process, ?string $password = null): static
     {
         return $this->addStep($success, [
             'isSuccessful' => $process->isSuccessful(),

--- a/tests/Adapters/MSOfficeCryptoToolAdapterTest.php
+++ b/tests/Adapters/MSOfficeCryptoToolAdapterTest.php
@@ -29,7 +29,7 @@ class MSOfficeCryptoToolAdapterTest extends AdapterTests
                 $this->getPasswords()
             );
 
-        $this->assertTrue($result);
+        $this->assertTrue($result->isSuccessful());
         $this->assertFilesExtracted([
             'simple.doc',
         ]);
@@ -46,7 +46,7 @@ class MSOfficeCryptoToolAdapterTest extends AdapterTests
                 $this->getPasswords()
             );
 
-        $this->assertTrue($result);
+        $this->assertTrue($result->isSuccessful());
         $this->assertFilesExtracted([
             'protected.ppt',
         ]);
@@ -60,6 +60,6 @@ class MSOfficeCryptoToolAdapterTest extends AdapterTests
             'wrongpassword',
         ]));
 
-        $this->assertFalse($result);
+        $this->assertFalse($result->isSuccessful());
     }
 }

--- a/tests/Adapters/QpdfAdapterTest.php
+++ b/tests/Adapters/QpdfAdapterTest.php
@@ -29,7 +29,7 @@ class QpdfAdapterTest extends AdapterTests
                 $this->getPasswords()
             );
 
-        $this->assertTrue($result);
+        $this->assertTrue($result->isSuccessful());
         $this->assertFilesExtracted([
             'simple.pdf',
         ]);
@@ -42,7 +42,7 @@ class QpdfAdapterTest extends AdapterTests
         $result = $this->adepter()
             ->extract($archivePath, $this->getExtractionPath(), $this->getPasswords());
 
-        $this->assertTrue($result);
+        $this->assertTrue($result->isSuccessful());
         $this->assertFilesExtracted([
             'protected.pdf',
         ]);
@@ -56,6 +56,6 @@ class QpdfAdapterTest extends AdapterTests
             'wrongpassword',
         ]));
 
-        $this->assertFalse($result);
+        $this->assertFalse($result->isSuccessful());
     }
 }

--- a/tests/Adapters/SevenZipAdapterTest.php
+++ b/tests/Adapters/SevenZipAdapterTest.php
@@ -41,7 +41,7 @@ class SevenZipAdapterTest extends AdapterTests
                 $this->getPasswords()
             );
 
-        $this->assertTrue($result);
+        $this->assertTrue($result->isSuccessful());
         $this->assertFilesExtracted();
     }
 
@@ -56,7 +56,7 @@ class SevenZipAdapterTest extends AdapterTests
                 $this->getPasswords()
             );
 
-        $this->assertTrue($result);
+        $this->assertTrue($result->isSuccessful());
         $this->assertFilesExtracted();
     }
 
@@ -73,7 +73,7 @@ class SevenZipAdapterTest extends AdapterTests
                 ])
             );
 
-        $this->assertFalse($result);
+        $this->assertFalse($result->isSuccessful());
         // $this->assertFilesDoesExtracted();
     }
 }

--- a/tests/ExtractorTest.php
+++ b/tests/ExtractorTest.php
@@ -143,7 +143,6 @@ class ExtractorTest extends TestCase
         $this->assertTrue($result->isSuccessful());
     }
 
-
     private function createSummary(bool $status = true, Collection|array $steps = []): SummaryInterface
     {
         $summary = $this->createMock(SummaryInterface::class);


### PR DESCRIPTION
This PR proposes replacing the use of a boolean (`true`/`false`) return value in the `extract` method of the `AdapterInterface` with a result object implementing the `SummaryInterface`.


#### Benefits

- **Enhanced Traceability**: Each step of the operation and its context (success/failure) is recorded, simplifying diagnostics.
- **Flexibility**: Easily add new fields like execution time or methods without breaking compatibility.
- **Improved Testing**: The result object makes mocking and verifying data in tests straightforward.


#### Example Usage

**Before**:
```php
if ($adapter->extract($filePath, $destination, $passwords)) {
    echo 'Extraction successful!';
} else {
    echo 'Extraction failed!';
}
```

**After**:
```php
$summary = $adapter->extract($filePath, $destination, $passwords);

if ($summary->isSuccessful()) {
    echo 'Extraction successful!';
    foreach ($summary->steps() as $step) {
        // Log steps or handle context
    }
} else {
    echo 'Extraction failed!';
    // Handle errors or failed steps from $summary->steps()
}
```